### PR TITLE
Added generic object support for SelectBox

### DIFF
--- a/src/main/java/org/liquidengine/legui/component/SelectBox.java
+++ b/src/main/java/org/liquidengine/legui/component/SelectBox.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.joml.Vector2f;
 import org.liquidengine.legui.component.event.selectbox.SelectBoxChangeSelectionEvent;
+import org.liquidengine.legui.component.event.selectbox.SelectBoxChangeSelectionEventListener;
 import org.liquidengine.legui.component.misc.animation.selectbox.SelectBoxAnimation;
 import org.liquidengine.legui.component.misc.listener.selectbox.SelectBoxClickListener;
 import org.liquidengine.legui.component.misc.listener.selectbox.SelectBoxElementClickListener;
@@ -34,7 +35,7 @@ import org.liquidengine.legui.theme.Themes;
 /**
  * Creates drop-down list with select options. <p> TODO: REIMPLEMENT THIS COMPONENT ACCORDING TO NEW LAYOUT SYSTEM
  */
-public class SelectBox extends Component {
+public class SelectBox<T> extends Component {
 
     public static final int EXPAND_ICON_CHAR = 0xE5C5;
     public static final int COLLAPSE_ICON_CHAR = 0xE5C7;
@@ -49,13 +50,13 @@ public class SelectBox extends Component {
     private Icon expandIcon;
     private Icon collapseIcon;
 
-    private List<SelectBoxElement> selectBoxElements = new CopyOnWriteArrayList<>();
-    private List<String> elements = new CopyOnWriteArrayList<>();
+    private List<SelectBoxElement<T>> selectBoxElements = new CopyOnWriteArrayList<>();
+    private List<T> elements = new CopyOnWriteArrayList<>();
 
     private SelectBoxScrollablePanel selectionListPanel = new SelectBoxScrollablePanel();
     private final SelectBoxScrollListener selectBoxScrollListener = new SelectBoxScrollListener(selectionListPanel.getVerticalScrollBar());
     private Button selectionButton = new Button(NULL);
-    private String selectedElement = null;
+    private T selectedElement = null;
     private float elementHeight = 16;
     private float buttonWidth = 15f;
     private int visibleCount = 3;
@@ -102,7 +103,7 @@ public class SelectBox extends Component {
      *
      * @return all elements of list.
      */
-    public List<String> getElements() {
+    public List<T> getElements() {
         return elements;
     }
 
@@ -129,7 +130,7 @@ public class SelectBox extends Component {
      *
      * @return selected element.
      */
-    public String getSelection() {
+    public T getSelection() {
         return selectedElement;
     }
 
@@ -163,12 +164,12 @@ public class SelectBox extends Component {
         this.add(expandButton);
         this.add(selectionButton);
 
-        MouseClickEventListener mouseClickEventListener = new SelectBoxClickListener(this);
+        MouseClickEventListener mouseClickEventListener = new SelectBoxClickListener<>(this);
         selectionButton.getListenerMap().addListener(MouseClickEvent.class, mouseClickEventListener);
         expandButton.getListenerMap().addListener(MouseClickEvent.class, mouseClickEventListener);
         selectBoxLayer.getContainer().getListenerMap().addListener(MouseClickEvent.class, mouseClickEventListener);
 
-        FocusEventListener focusEventListener = new SelectBoxFocusListener(this);
+        FocusEventListener focusEventListener = new SelectBoxFocusListener<>(this);
         selectionListPanel.getVerticalScrollBar().getListenerMap().getListeners(FocusEvent.class).add(focusEventListener);
         selectionButton.getListenerMap().getListeners(FocusEvent.class).add(focusEventListener);
         expandButton.getListenerMap().getListeners(FocusEvent.class).add(focusEventListener);
@@ -259,7 +260,7 @@ public class SelectBox extends Component {
      */
     private void resize() {
         updateIcons();
-        for (SelectBoxElement selectBoxElement : selectBoxElements) {
+        for (SelectBoxElement<T> selectBoxElement : selectBoxElements) {
             selectBoxElement.getStyle().setMinimumSize(0, elementHeight);
         }
     }
@@ -270,15 +271,15 @@ public class SelectBox extends Component {
      *
      * @param element element to add.
      */
-    public void addElement(String element) {
+    public void addElement(T element) {
         lock.lock();
         try {
             if (!elements.contains(element)) {
 
-                SelectBoxElement boxElement = createSelectBoxElement(element);
+                SelectBoxElement<T> boxElement = createSelectBoxElement(element);
                 if (elements.isEmpty()) {
                     selectedElement = element;
-                    selectionButton.getTextState().setText(element);
+                    selectionButton.getTextState().setText(element == null ? NULL : element.toString());
                 }
                 elements.add(element);
                 selectBoxElements.add(boxElement);
@@ -296,12 +297,12 @@ public class SelectBox extends Component {
      * @param element element.
      * @return {@link SelectBoxElement} created on base of element.
      */
-    private SelectBoxElement createSelectBoxElement(String element) {
-        SelectBoxElement boxElement = new SelectBoxElement(element, false);
+    private SelectBoxElement<T> createSelectBoxElement(T element) {
+        SelectBoxElement<T> boxElement = new SelectBoxElement<>(element, false);
         boxElement.getStyle().setHeight(elementHeight);
         boxElement.getStyle().setMinHeight(elementHeight);
         boxElement.getStyle().setPosition(PositionType.RELATIVE);
-        boxElement.getListenerMap().getListeners(MouseClickEvent.class).add(new SelectBoxElementClickListener(this));
+        boxElement.getListenerMap().getListeners(MouseClickEvent.class).add(new SelectBoxElementClickListener<>(this));
         return boxElement;
     }
 
@@ -311,7 +312,7 @@ public class SelectBox extends Component {
      * @param element element to find index.
      * @return index of element or -1 if no such element in selectbox.
      */
-    public int getElementIndex(String element) {
+    public int getElementIndex(T element) {
         return elements.indexOf(element);
     }
 
@@ -320,7 +321,7 @@ public class SelectBox extends Component {
      *
      * @param element element to remove from selectbox.
      */
-    public void removeElement(String element) {
+    public void removeElement(T element) {
         removeElement(elements.indexOf(element));
     }
 
@@ -333,9 +334,9 @@ public class SelectBox extends Component {
         lock.lock();
         try {
             if (elements.size() != 0) {
-                String s = elements.get(index);
+                T s = elements.get(index);
                 elements.remove(index);
-                SelectBoxElement element = selectBoxElements.get(index);
+                SelectBoxElement<T> element = selectBoxElements.get(index);
                 selectBoxElements.remove(index);
                 selectionListPanel.getContainer().remove(element);
                 for (int i = index; i < selectBoxElements.size(); i++) {
@@ -356,7 +357,7 @@ public class SelectBox extends Component {
      * @param element element to set state.
      * @param selected state of element to set.
      */
-    public void setSelected(String element, boolean selected) {
+    public void setSelected(T element, boolean selected) {
         int index = elements.indexOf(element);
         setSelected(element, selected, index);
     }
@@ -369,7 +370,7 @@ public class SelectBox extends Component {
      */
     public void setSelected(int index, boolean selected) {
         if (elements.size() > 0) {
-            String element = elements.get(index);
+            T element = elements.get(index);
             setSelected(element, selected, index);
         } else {
             selectedElement = null;
@@ -377,17 +378,17 @@ public class SelectBox extends Component {
         }
     }
 
-    private void setSelected(String element, boolean selected, int index) {
+    private void setSelected(T element, boolean selected, int index) {
         if (selected) {
             if (index != -1) {
-                SelectBoxElement tSelectBoxElement = selectBoxElements.get(index);
+                SelectBoxElement<T> tSelectBoxElement = selectBoxElements.get(index);
                 tSelectBoxElement.selected = true;
                 int selectedIndex = elements.indexOf(selectedElement);
                 if (selectedIndex != -1) {
                     selectBoxElements.get(index).selected = false;
                 }
                 selectedElement = element;
-                selectionButton.getTextState().setText(element);
+                selectionButton.getTextState().setText(element == null ? NULL : element.toString());
             } else {
                 addElement(element);
                 setSelected(element, true);
@@ -428,8 +429,8 @@ public class SelectBox extends Component {
      *
      * @param eventListener event listener to add.
      */
-    public void addSelectBoxChangeSelectionEventListener(EventListener<SelectBoxChangeSelectionEvent> eventListener) {
-        this.getListenerMap().addListener(SelectBoxChangeSelectionEvent.class, eventListener);
+    public void addSelectBoxChangeSelectionEventListener(EventListener<SelectBoxChangeSelectionEvent<T>> eventListener) {
+        this.getListenerMap().addListener(SelectBoxChangeSelectionEvent.class, (EventListener) eventListener);
     }
 
     /**
@@ -437,8 +438,8 @@ public class SelectBox extends Component {
      *
      * @return all event listeners for select box change selection event.
      */
-    public List<EventListener<SelectBoxChangeSelectionEvent>> getSelectBoxChangeSelectionEvents() {
-        return this.getListenerMap().getListeners(SelectBoxChangeSelectionEvent.class);
+    public List<EventListener<SelectBoxChangeSelectionEvent<T>>> getSelectBoxChangeSelectionEvents() {
+        return List.class.cast(this.getListenerMap().getListeners(SelectBoxChangeSelectionEvent.class));
     }
 
     /**
@@ -446,8 +447,8 @@ public class SelectBox extends Component {
      *
      * @param eventListener event listener to remove.
      */
-    public void removeSelectBoxChangeSelectionEventListener(EventListener<SelectBoxChangeSelectionEvent> eventListener) {
-        this.getListenerMap().removeListener(SelectBoxChangeSelectionEvent.class, eventListener);
+    public void removeSelectBoxChangeSelectionEventListener(SelectBoxChangeSelectionEventListener<T> eventListener) {
+        this.getListenerMap().removeListener(SelectBoxChangeSelectionEvent.class, (EventListener) eventListener);
     }
 
     @Override
@@ -495,7 +496,7 @@ public class SelectBox extends Component {
      *
      * @return the select box elements
      */
-    public List<SelectBoxElement> getSelectBoxElements() {
+    public List<SelectBoxElement<T>> getSelectBoxElements() {
         return selectBoxElements;
     }
 
@@ -524,22 +525,22 @@ public class SelectBox extends Component {
     /**
      * Selectbox element which is subclass of button.
      */
-    public class SelectBoxElement extends Button {
+    public class SelectBoxElement<T> extends Button {
 
         private boolean selected;
-        private String text;
+        private T object;
 
-        private SelectBoxElement(String text, boolean selected) {
-            super(text == null ? "null" : text);
+        private SelectBoxElement(T object, boolean selected) {
+            super(object == null ? "null" : object.toString());
             this.selected = selected;
-            this.text = text;
+            this.object = object;
             this.getStyle().setBorder(null);
 
             Themes.getDefaultTheme().apply(this);
         }
 
-        public String getText() {
-            return text;
+        public T getObject() {
+            return object;
         }
 
         /**
@@ -582,7 +583,7 @@ public class SelectBox extends Component {
             return new EqualsBuilder()
                 .appendSuper(super.equals(o))
                 .append(selected, that.selected)
-                .append(text, that.text)
+                .append(object, that.object)
                 .isEquals();
         }
 

--- a/src/main/java/org/liquidengine/legui/component/event/selectbox/SelectBoxChangeSelectionEvent.java
+++ b/src/main/java/org/liquidengine/legui/component/event/selectbox/SelectBoxChangeSelectionEvent.java
@@ -8,12 +8,12 @@ import org.liquidengine.legui.system.context.Context;
 /**
  * @author ShchAlexander.
  */
-public class SelectBoxChangeSelectionEvent<T extends SelectBox> extends Event<T> {
+public class SelectBoxChangeSelectionEvent<T> extends Event<SelectBox<T>> {
 
-    private final String oldValue;
-    private final String newValue;
+    private final T oldValue;
+    private final T newValue;
 
-    public SelectBoxChangeSelectionEvent(T component, Context context, Frame frame, String oldValue, String newValue) {
+    public SelectBoxChangeSelectionEvent(SelectBox<T> component, Context context, Frame frame, T oldValue, T newValue) {
         super(component, context, frame);
         this.oldValue = oldValue;
         this.newValue = newValue;
@@ -24,7 +24,7 @@ public class SelectBoxChangeSelectionEvent<T extends SelectBox> extends Event<T>
      *
      * @return old value.
      */
-    public String getOldValue() {
+    public T getOldValue() {
         return oldValue;
     }
 
@@ -33,7 +33,7 @@ public class SelectBoxChangeSelectionEvent<T extends SelectBox> extends Event<T>
      *
      * @return new value.
      */
-    public String getNewValue() {
+    public T getNewValue() {
         return newValue;
     }
 }

--- a/src/main/java/org/liquidengine/legui/component/event/selectbox/SelectBoxChangeSelectionEventListener.java
+++ b/src/main/java/org/liquidengine/legui/component/event/selectbox/SelectBoxChangeSelectionEventListener.java
@@ -5,7 +5,7 @@ import org.liquidengine.legui.listener.EventListener;
 /**
  * @author ShchAlexander.
  */
-public interface SelectBoxChangeSelectionEventListener extends EventListener<SelectBoxChangeSelectionEvent> {
+public interface SelectBoxChangeSelectionEventListener<T> extends EventListener<SelectBoxChangeSelectionEvent<T>> {
 
     /**
      * Used to handle {@link SelectBoxChangeSelectionEvent} event.
@@ -13,6 +13,6 @@ public interface SelectBoxChangeSelectionEventListener extends EventListener<Sel
      * @param event event to handle.
      */
     @Override
-    void process(SelectBoxChangeSelectionEvent event);
+    void process(SelectBoxChangeSelectionEvent<T> event);
 
 }

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxClickListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxClickListener.java
@@ -14,17 +14,17 @@ import org.liquidengine.legui.listener.MouseClickEventListener;
  * <p>
  * Used to expand/collapse selectbox if clicked on it.
  */
-public class SelectBoxClickListener implements MouseClickEventListener {
+public class SelectBoxClickListener<T> implements MouseClickEventListener {
 
-    private SelectBox selectBox;
+    private SelectBox<T> selectBox;
 
-    public SelectBoxClickListener(SelectBox selectBox) {
+    public SelectBoxClickListener(SelectBox<T> selectBox) {
         this.selectBox = selectBox;
     }
 
     @Override
     public void process(MouseClickEvent event) {
-        SelectBox box = selectBox;
+        SelectBox<T> box = selectBox;
         if (event.getAction() == CLICK) {
             Frame frame = event.getFrame();
             SelectBoxLayer selectBoxLayer = box.getSelectBoxLayer();

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxElementClickListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxElementClickListener.java
@@ -12,22 +12,22 @@ import org.liquidengine.legui.listener.processor.EventProcessor;
 /**
  * @author ShchAlexander.
  */
-public class SelectBoxElementClickListener implements MouseClickEventListener {
+public class SelectBoxElementClickListener<T> implements MouseClickEventListener {
 
-    private SelectBox selectBox;
+    private SelectBox<T> selectBox;
 
-    public SelectBoxElementClickListener(SelectBox selectBox) {
+    public SelectBoxElementClickListener(SelectBox<T> selectBox) {
         this.selectBox = selectBox;
     }
 
     @Override
     public void process(MouseClickEvent event) {
-        SelectBox.SelectBoxElement component = (SelectBox.SelectBoxElement) event.getTargetComponent();
+        SelectBox<T>.SelectBoxElement<T> component = (SelectBox<T>.SelectBoxElement<T>) event.getTargetComponent();
         if (event.getAction() == CLICK && event.getButton().equals(Mouse.MouseButton.MOUSE_BUTTON_1)) {
-            String selection = selectBox.getSelection();
-            String newValue = component.getText();
+            T selection = selectBox.getSelection();
+            T newValue = component.getObject();
             selectBox.setSelected(newValue, true);
-            EventProcessor.getInstance().pushEvent(new SelectBoxChangeSelectionEvent(selectBox, event.getContext(), event.getFrame(), selection, newValue));
+            EventProcessor.getInstance().pushEvent(new SelectBoxChangeSelectionEvent<>(selectBox, event.getContext(), event.getFrame(), selection, newValue));
             selectBox.setCollapsed(true);
             event.getFrame().removeLayer(selectBox.getSelectBoxLayer());
         }

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxFocusListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxFocusListener.java
@@ -8,11 +8,11 @@ import org.liquidengine.legui.listener.FocusEventListener;
 /**
  * Default focus listener for selectbox. Used to collapse selectbox if it loses focus.
  */
-public class SelectBoxFocusListener implements FocusEventListener {
+public class SelectBoxFocusListener<T> implements FocusEventListener {
 
-    private SelectBox selectBox;
+    private SelectBox<T> selectBox;
 
-    public SelectBoxFocusListener(SelectBox selectBox) {
+    public SelectBoxFocusListener(SelectBox<T> selectBox) {
         this.selectBox = selectBox;
     }
 
@@ -21,7 +21,7 @@ public class SelectBoxFocusListener implements FocusEventListener {
         if (!event.isFocused() && !selectBox.isCollapsed()) {
             boolean collapse = true;
             Component nextFocus = event.getNextFocus();
-            for (SelectBox.SelectBoxElement selectBoxElement : selectBox.getSelectBoxElements()) {
+            for (SelectBox<T>.SelectBoxElement<T> selectBoxElement : selectBox.getSelectBoxElements()) {
                 if (nextFocus == selectBoxElement) {
                     collapse = false;
                 }

--- a/src/main/java/org/liquidengine/legui/demo/ExampleGui.java
+++ b/src/main/java/org/liquidengine/legui/demo/ExampleGui.java
@@ -35,6 +35,7 @@ import org.liquidengine.legui.component.TextInput;
 import org.liquidengine.legui.component.ToggleButton;
 import org.liquidengine.legui.component.Tooltip;
 import org.liquidengine.legui.component.Widget;
+import org.liquidengine.legui.component.event.selectbox.SelectBoxChangeSelectionEventListener;
 import org.liquidengine.legui.component.event.slider.SliderChangeValueEvent;
 import org.liquidengine.legui.component.event.slider.SliderChangeValueEventListener;
 import org.liquidengine.legui.component.optional.Orientation;
@@ -420,31 +421,28 @@ public class ExampleGui extends Panel {
         inpur.getStyle().getBackground().setColor(ColorConstants.white());
         this.add(inpur);
 
-        SelectBox selectBox = new SelectBox(20, 260, 100, 20);
-        selectBox.addElement("Just");
-        selectBox.addElement("Hello");
-        selectBox.addElement("World");
-        final int[] i = {1};
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.addElement("World" + i[0]++);
-        selectBox.setVisibleCount(5);
+        SelectBox<Object> selectBox = new SelectBox<>(20, 260, 100, 20);
+        selectBox.addElement(0.25f);
+        selectBox.addElement(0.5d);
+        selectBox.addElement(1);
+        selectBox.addElement("MyText");
+        selectBox.addElement(new Long(2L));
+        selectBox.setVisibleCount(7);
         selectBox.setElementHeight(20);
+        selectBox.addSelectBoxChangeSelectionEventListener((SelectBoxChangeSelectionEventListener<Object>) event -> {
+            Dialog dialog = new Dialog("SelectBox clicked", 300, 100);
+            Label valueLabel = new Label("Value: " + event.getNewValue().toString(), 10, 10, 300, 20);
+            dialog.getContainer().add(valueLabel);
+            Label classLabel = new Label("Class: " + event.getNewValue().getClass().getName(), 10, 30, 300, 20);
+            dialog.getContainer().add(classLabel);
+            dialog.show(event.getFrame());
+        });
         this.add(selectBox);
 
         Button sbb = new Button("Add element", 130, 260, 70, 20);
         sbb.getListenerMap().addListener(MouseClickEvent.class, (MouseClickEventListener) event -> {
             if (event.getAction() == CLICK) {
-                selectBox.addElement("WorlD " + i[0]++);
+                selectBox.addElement("Dynamic#" + selectBox.getElements().size());
             }
         });
         this.add(sbb);


### PR DESCRIPTION
SelectBoxes should be able to contain any object (instead of Strings only). The result of #toString() should be used for the displayed text. 

This way the SelectBox can be used in various ways when using it in a complex scenario (for example when using enums).

This behaviour is analogous to the java sdk.