### PR TITLE
Listeners update

### DIFF
--- a/src/main/java/org/liquidengine/legui/component/misc/listener/checkbox/CheckBoxMouseClickEventListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/checkbox/CheckBoxMouseClickEventListener.java
@@ -21,7 +21,7 @@ public class CheckBoxMouseClickEventListener implements MouseClickEventListener 
     @Override
     public void process(MouseClickEvent event) {
         CheckBox checkBox = (CheckBox) event.getTargetComponent();
-        if (event.getAction() == CLICK) {
+        if (event.getAction() == CLICK && check.isEnabled()) {
             boolean checked = checkBox.isChecked();
             checkBox.setChecked(!checked);
             EventProcessorProvider.getInstance().pushEvent(new CheckBoxChangeValueEvent(checkBox, event.getContext(), event.getFrame(), checked, !checked));

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/checkbox/CheckBoxMouseClickEventListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/checkbox/CheckBoxMouseClickEventListener.java
@@ -21,10 +21,10 @@ public class CheckBoxMouseClickEventListener implements MouseClickEventListener 
     @Override
     public void process(MouseClickEvent event) {
         CheckBox checkBox = (CheckBox) event.getTargetComponent();
-        if (event.getAction() == CLICK && check.isEnabled()) {
+        if (event.getAction() == CLICK && checkBox.isEnabled()) {
             boolean checked = checkBox.isChecked();
             checkBox.setChecked(!checked);
-            EventProcessorProvider.getInstance().pushEvent(new CheckBoxChangeValueEvent(checkBox, event.getContext(), event.getFrame(), checked, !checked));
+            EventProcessorProvider.getInstance().pushEvent(new CheckBoxChangeValueEvent<>(checkBox, event.getContext(), event.getFrame(), checked, !checked));
         }
     }
 }

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxClickListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxClickListener.java
@@ -24,7 +24,7 @@ public class SelectBoxClickListener<T> implements MouseClickEventListener {
     @Override
     public void process(MouseClickEvent event) {
         SelectBox<T> box = selectBox;
-        if (event.getAction() == CLICK) {
+        if (event.getAction() == CLICK && selectBox.isEnabled()) {
             Frame frame = event.getFrame();
             SelectBox.SelectBoxLayer selectBoxLayer = box.getSelectBoxLayer();
             boolean collapsed = box.isCollapsed();

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxElementClickListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxElementClickListener.java
@@ -23,7 +23,7 @@ public class SelectBoxElementClickListener<T> implements MouseClickEventListener
     @Override
     public void process(MouseClickEvent event) {
         SelectBox<T>.SelectBoxElement<T> component = (SelectBox<T>.SelectBoxElement<T>) event.getTargetComponent();
-        if (event.getAction() == CLICK && event.getButton().equals(Mouse.MouseButton.MOUSE_BUTTON_1)) {
+        if (event.getAction() == CLICK && event.getButton().equals(Mouse.MouseButton.MOUSE_BUTTON_1) && selectBox.isEnabled()) {
             T selection = selectBox.getSelection();
             T newValue = component.getObject();
             selectBox.setSelected(newValue, true);

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxFocusListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/selectbox/SelectBoxFocusListener.java
@@ -18,7 +18,7 @@ public class SelectBoxFocusListener<T> implements FocusEventListener {
 
     @Override
     public void process(FocusEvent event) {
-        if (!event.isFocused() && !selectBox.isCollapsed()) {
+        if (!event.isFocused() && !selectBox.isCollapsed() && selectBox.isEnabled()) {
             boolean collapse = true;
             Component nextFocus = event.getNextFocus();
             for (SelectBox<T>.SelectBoxElement<T> selectBoxElement : selectBox.getSelectBoxElements()) {

--- a/src/main/java/org/liquidengine/legui/component/misc/listener/togglebutton/ToggleButtonMouseClickListener.java
+++ b/src/main/java/org/liquidengine/legui/component/misc/listener/togglebutton/ToggleButtonMouseClickListener.java
@@ -12,7 +12,7 @@ public class ToggleButtonMouseClickListener implements MouseClickEventListener {
     @Override
     public void process(MouseClickEvent event) {
         ToggleButton toggleButton = (ToggleButton) event.getTargetComponent();
-        if (event.getAction() == MouseClickEvent.MouseClickAction.CLICK) {
+        if (event.getAction() == MouseClickEvent.MouseClickAction.CLICK && toggleButton.isEnabled()) {
             toggleButton.setToggled(!toggleButton.isToggled());
         }
     }


### PR DESCRIPTION
Allows to skip default processing of events for disabled components.
We still can declare our custom event listeners to add additional event processing.